### PR TITLE
rs5002redis: Password is stored as string and not int

### DIFF
--- a/src/rs5002redis/saver.py
+++ b/src/rs5002redis/saver.py
@@ -10,7 +10,7 @@ def save_data_to_redis(data: dict, config_file: str) -> None:
     host = conf.get(section='redis', option='host', fallback='localhost')
     port = conf.getint(section='redis', option='port', fallback=6379)
     db = conf.getint(section='redis', option='db', fallback=0)
-    password = conf.getint(section='redis', option='password', fallback=None)
+    password = conf.get(section='redis', option='password', fallback=None)
     ttl = conf.getint(section='redis', option='result_lifetime_seconds', fallback=30)
     prefix = conf.get(section='redis', option='prefix', fallback='')
     try:


### PR DESCRIPTION
Hi,
der Wert für das Passwort wird falsch ausgelesen und wirft bei mir folgenden Fehler:

````
 python save_rs500_to_redis.py 
Traceback (most recent call last):
  File "save_rs500_to_redis.py", line 23, in <module>
    fetch_and_save()
  File "save_rs500_to_redis.py", line 19, in fetch_and_save
    save_data_to_redis(to_save, './' + 'rs5002redis.ini')
  File "/home/chip/raumklima/src/rs5002redis/saver.py", line 13, in save_data_to_redis
    password = conf.getint(section='redis', option='password', fallback=None)
  File "/usr/lib/python3.4/configparser.py", line 781, in getint
    return self._get(section, int, option, raw=raw, vars=vars)
  File "/usr/lib/python3.4/configparser.py", line 776, in _get
    return conv(self.get(section, option, **kwargs))
ValueError: invalid literal for int() with base 10: 'xxxxx'
````
Anbei der kleine Bugfix.