### PR TITLE
Fix für hängende Prozesse bei Backend-Problemen

### DIFF
--- a/src/check_rs500.ini
+++ b/src/check_rs500.ini
@@ -4,6 +4,12 @@ host = raumklima
 port = 6379
 db = 3
 prefix = rs500_
+# Socket & Connect timeout.
+# Remember: if you run within a 30s cronjob
+#           you should end the thread within
+#           this interval
+socket_timeout=10
+
 
 
 [mqtt]

--- a/src/check_rs500.ini
+++ b/src/check_rs500.ini
@@ -8,11 +8,18 @@ prefix = rs500_
 
 [mqtt]
 enabled = False
-host = raumklime
+host = raumklima
 # NONTLS
 port = 1883
 # TODO: Implement TLS
 # port = 8883
+
+# Connection Keepalive
+#  and connect timeout.
+# Remember: if you run within a 30s cronjob
+#           you should end the thread within
+#           this interval
+keepalive=10
 
 # If you broker requires user & password
 #username =

--- a/src/check_rs500.py
+++ b/src/check_rs500.py
@@ -57,10 +57,11 @@ def handle_request(args: argparse.Namespace):
     host = conf.get(section='redis', option='host', fallback='localhost')
     port = conf.getint(section='redis', option='port', fallback=6379)
     db = conf.getint(section='redis', option='db', fallback=0)
+    socket_timeout = conf.getint(section='redis', option='socket_timeout', fallback=30)
     password = conf.getint(section='redis', option='password', fallback=None)
     prefix = conf.get(section='redis', option='prefix', fallback='')
     try:
-        redis = StrictRedis(host=host, port=port, db=db, password=password)
+        redis = StrictRedis(host=host, port=port, db=db, password=password, socket_timeout=socket_timeout)
         raw_value_temp = redis.get('{0}c{1}_temp'.format(prefix, args.channel))
         raw_value_humi = redis.get('{0}c{1}_humi'.format(prefix, args.channel))
         if raw_value_temp is None and raw_value_humi is None:

--- a/src/rs5002backend.ini
+++ b/src/rs5002backend.ini
@@ -15,6 +15,13 @@ port = 1883
 # TODO: Implement TLS
 # port = 8883
 
+# Connection Keepalive
+#  and connect timeout.
+# Remember: if you run within a 30s cronjob
+#           you should end the thread within
+#           this interval
+keepalive=10
+
 # If you broker requires user & password
 #username =
 #password =

--- a/src/rs5002backend.ini
+++ b/src/rs5002backend.ini
@@ -5,6 +5,11 @@ port = 6379
 db = 3
 prefix = rs500_
 result_lifetime_seconds = 45
+# Socket & Connect timeout.
+# Remember: if you run within a 30s cronjob
+#           you should end the thread within
+#           this interval
+socket_timeout=10
 
 
 [mqtt]

--- a/src/rs5002mqtt/saver.py
+++ b/src/rs5002mqtt/saver.py
@@ -18,6 +18,7 @@ def save_data_to_mqtt(data: dict, config_file: str) -> None:
     conf = ConfigProvider(config_file).get_config()
     host = conf.get(section="mqtt", option="host", fallback="localhost")
     port = conf.getint(section="mqtt", option="port", fallback=1883)
+    keepalive = conf.getint(section="mqtt", option="keepalive", fallback=10)
     client_id = conf.get(section="mqtt", option="clientid", fallback="rs5002mqtt")
     topic_prefix = conf.get(section="mqtt", option="topic_prefix", fallback="rs500")
     topic_suffix = conf.get(section="mqtt", option="topic_suffix", fallback="")
@@ -41,7 +42,7 @@ def save_data_to_mqtt(data: dict, config_file: str) -> None:
     if username is not None and password is not None:
         client.username_pw_set(username, password)
 
-    client.connect(host, port)
+    client.connect(host, port, keepalive=keepalive )
 
     published_messages = []
 

--- a/src/rs5002redis/saver.py
+++ b/src/rs5002redis/saver.py
@@ -9,12 +9,13 @@ def save_data_to_redis(data: dict, config_file: str) -> None:
     conf = ConfigProvider(config_file).get_config()
     host = conf.get(section='redis', option='host', fallback='localhost')
     port = conf.getint(section='redis', option='port', fallback=6379)
+    socket_timeout = conf.getint(section='redis', option='socket_timeout', fallback=30)
     db = conf.getint(section='redis', option='db', fallback=0)
     password = conf.get(section='redis', option='password', fallback=None)
     ttl = conf.getint(section='redis', option='result_lifetime_seconds', fallback=30)
     prefix = conf.get(section='redis', option='prefix', fallback='')
     try:
-        redis = StrictRedis(host=host, port=port, db=db, password=password)
+        redis = StrictRedis(host=host, port=port, db=db, password=password, socket_timeout=socket_timeout)
         with redis.pipeline() as pipe:
             for k, v in data.items():
                 key = '{0}{1}'.format(prefix, k)


### PR DESCRIPTION
Falls die verwendeten Server Probleme haben und z.B. Packete droppen, bleibt der Client unnötig lange aktive. Bei einem 30s Intervall für das Update führt das dazu, dass 1-chip Computer in Probleme laufen können.

Fixes #47